### PR TITLE
Add editorconfig as an example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
### Context
Link to ticket: **No linked ticket**

### What has been done
- `.editorconfig` added

### Notes
Clarification on the rules in there:
* `root` indicates whether this is the top `.editorconfig` file (if not, it recursively looks at its parent folders for `.editorconfig` files
* `[*]` indicates the rules below it apply on **all** files
* `indent_style` indicates whether spaces or tabs should be used
* `indent_size` indicates the level of indentation
* `end_of_line` can be `lf` (`\n`), `cr` (`\r`) or `crlf` (`\r\n`)
* `charset` indicates the character set used for the files you store in your editor
* `trim_trailing_whitespace` trims trailing whitespace from a line automatically if the editor supports is
* `insert_final_newline` inserts a final newline at the end of each file (the why: http://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline)
* `[*.md]` are rules that only apply on markdown documents